### PR TITLE
Reject Cloud SQL Unix sockets in PostgreSQL MCP

### DIFF
--- a/mcp/postgresql-mcp/internal/cloudguard/cloudguard_test.go
+++ b/mcp/postgresql-mcp/internal/cloudguard/cloudguard_test.go
@@ -59,10 +59,10 @@ func TestValidateConnection(t *testing.T) {
 			errorText:   "detected 'instance' parameter",
 		},
 		{
-			name:        "Cloud SQL with host parameter pointing to cloudsql",
-			dsn:         "postgresql://user:pass@localhost:5432/mydb?host=/cloudsql/my-project:us-central1:my-instance",
+			name:        "Cloud SQL with encoded host parameter pointing to cloudsql",
+			dsn:         "postgresql://user:pass@localhost:5432/mydb?host=%2Fcloudsql%2Fmy-project:us-central1:my-instance",
 			shouldError: true,
-			errorText:   "detected Cloud SQL Unix socket path",
+			errorText:   "detected Cloud SQL Unix socket path in ?host",
 		},
 		{
 			name:        "Regular localhost connection on standard port",
@@ -79,13 +79,13 @@ func TestValidateConnection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateConnection(tt.dsn)
-			
+
 			if tt.shouldError {
 				if err == nil {
 					t.Errorf("Expected error for DSN %s, but got none", tt.dsn)
 					return
 				}
-				
+
 				// Check if it's the right type of error
 				if cloudErr, ok := err.(*CloudSQLProxyError); ok {
 					if !strings.Contains(cloudErr.Reason, tt.errorText) {
@@ -121,9 +121,9 @@ func TestDetectCloudSQLProxy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateConnection(tt.dsn)
 			hasError := err != nil
-			
+
 			if hasError != tt.expectError {
-				t.Errorf("DSN %s: expected error=%v, got error=%v (err: %v)", 
+				t.Errorf("DSN %s: expected error=%v, got error=%v (err: %v)",
 					tt.dsn, tt.expectError, hasError, err)
 			}
 		})

--- a/mcp/postgresql-mcp/internal/dbguard/dbguard.go
+++ b/mcp/postgresql-mcp/internal/dbguard/dbguard.go
@@ -34,7 +34,6 @@ func LoadPostgresURLsFromArgs(urlString string) ([]string, error) {
 	return out, nil
 }
 
-
 // EnforceLocalForURLs validates URLs are local and returns the original DSNs
 func EnforceLocalForURLs(urls []string) ([]string, error) {
 	out := make([]string, 0, len(urls))
@@ -54,6 +53,9 @@ func EnforceLocalForURLs(urls []string) ([]string, error) {
 func validateLocalURL(u *url.URL) error {
 	if hosts := u.Query()["host"]; len(hosts) > 0 {
 		for _, h := range hosts {
+			if strings.HasPrefix(h, "/cloudsql/") {
+				return fmt.Errorf("%w: cloud sql unix socket is forbidden: %q", errRemote, h)
+			}
 			if !strings.HasPrefix(h, "/") || !isUnderAllowedSocketRoots(h) {
 				return fmt.Errorf("%w: unix socket outside allowed roots: %q", errRemote, h)
 			}
@@ -77,6 +79,9 @@ func validateLocalURL(u *url.URL) error {
 		h = strings.Trim(h, "[]")
 
 		if strings.HasPrefix(h, "/") {
+			if strings.HasPrefix(h, "/cloudsql/") {
+				return fmt.Errorf("%w: cloud sql unix socket is forbidden: %q", errRemote, h)
+			}
 			if !isUnderAllowedSocketRoots(h) {
 				return fmt.Errorf("%w: unix socket outside allowed roots: %q", errRemote, h)
 			}

--- a/mcp/postgresql-mcp/internal/dbguard/dbguard_test.go
+++ b/mcp/postgresql-mcp/internal/dbguard/dbguard_test.go
@@ -20,14 +20,13 @@ func TestLoadPostgresURLsFromArgs(t *testing.T) {
 	if len(urls) != 2 {
 		t.Fatalf("expected 2 urls, got %d", len(urls))
 	}
-	
+
 	// Test empty string
 	_, err = LoadPostgresURLsFromArgs("")
 	if err == nil {
 		t.Fatalf("expected error for empty string")
 	}
 }
-
 
 func TestEnforceLocalForURLsAllow(t *testing.T) {
 	dsns := []string{"postgresql://u:p@localhost:5432/db?sslmode=disable", "postgresql://u:p@[::1]:5432/db"}
@@ -51,6 +50,20 @@ func TestEnforceLocalForURLsRejectMixed(t *testing.T) {
 	dsns := []string{"postgresql://u:p@localhost,10.0.0.5:5432/db"}
 	if _, err := EnforceLocalForURLs(dsns); err == nil {
 		t.Fatalf("expected error for mixed hosts")
+	}
+}
+
+func TestEnforceLocalForURLsRejectCloudSQLSocket(t *testing.T) {
+	dsns := []string{"postgresql://u:p@localhost:5432/db?host=/cloudsql/proj:reg:inst"}
+	if _, err := EnforceLocalForURLs(dsns); err == nil {
+		t.Fatalf("expected error for cloud sql unix socket")
+	}
+}
+
+func TestEnforceLocalForURLsRejectCloudSQLHost(t *testing.T) {
+	dsns := []string{"postgresql://u:p@/cloudsql/proj:reg:inst/db"}
+	if _, err := EnforceLocalForURLs(dsns); err == nil {
+		t.Fatalf("expected error for cloud sql unix socket host path")
 	}
 }
 


### PR DESCRIPTION
## Summary
- block `/cloudsql/` Unix socket paths during local URL validation
- detect Cloud SQL socket usage in DSNs and `?host` early in `cloudguard`
- test Cloud SQL socket rejection including encoded host param

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a1433c05e0832c8796b3a2cb61765e