### PR TITLE
feat: list assigned PR links via gh

### DIFF
--- a/scripts/gh-my-prs/go.mod
+++ b/scripts/gh-my-prs/go.mod
@@ -1,0 +1,4 @@
+module github.com/Ryota-Onuma/ai-agents/scripts/gh-my-prs
+
+go 1.25
+

--- a/scripts/gh-my-prs/main.go
+++ b/scripts/gh-my-prs/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func ghCmd() string {
+	if c := os.Getenv("GH_COMMAND"); c != "" {
+		return c
+	}
+	return "gh"
+}
+
+func getAssignedPRLinks(ctx context.Context) ([]string, error) {
+	cmd := exec.CommandContext(ctx, ghCmd(), "pr", "list", "--assignee", "@me", "--json", "url", "--jq", ".[].url")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh command failed: %w", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	var links []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			links = append(links, line)
+		}
+	}
+	return links, nil
+}
+
+func main() {
+	log.SetFlags(0)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	links, err := getAssignedPRLinks(ctx)
+	if err != nil {
+		log.Fatalf(`{"level":"error","msg":"%v"}`, err)
+	}
+	log.Printf(`{"level":"info","msg":"found pull requests","count":%d}`, len(links))
+	for _, l := range links {
+		fmt.Println(l)
+	}
+}

--- a/scripts/gh-my-prs/main_test.go
+++ b/scripts/gh-my-prs/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFakeGh(t *testing.T, content string, exitCode int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gh")
+	script := "#!/bin/sh\n" + content + "\nexit " + fmt.Sprintf("%d", exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write fake gh: %v", err)
+	}
+	return path
+}
+
+func TestGetAssignedPRLinks(t *testing.T) {
+	fake := writeFakeGh(t, "echo https://example.com/pr1\necho\necho https://example.com/pr2", 0)
+	t.Setenv("GH_COMMAND", fake)
+	links, err := getAssignedPRLinks(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	want := []string{"https://example.com/pr1", "https://example.com/pr2"}
+	if len(links) != len(want) {
+		t.Fatalf("unexpected link count: %d", len(links))
+	}
+	for i, l := range links {
+		if l != want[i] {
+			t.Errorf("link %d = %s; want %s", i, l, want[i])
+		}
+	}
+}
+
+func TestGetAssignedPRLinksError(t *testing.T) {
+	fake := writeFakeGh(t, "echo error 1>&2", 1)
+	t.Setenv("GH_COMMAND", fake)
+	if _, err := getAssignedPRLinks(context.Background()); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- add Go script to print URLs of PRs assigned to the current user using `gh`
- cover command with unit tests using a fake `gh` executable
- bump Go module version to 1.25

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a96fc053dc832c80be63dfac3d2b21